### PR TITLE
fix: workflow step and variables missing

### DIFF
--- a/fci-processing/fci-processing-tasks.yaml
+++ b/fci-processing/fci-processing-tasks.yaml
@@ -1,4 +1,7 @@
 ---
+- name: Include vars
+  ansible.builtin.include_vars: vars.yaml
+
 - name: Create install directory
   file:
     path: "{{ install_dir }}"

--- a/satellite-data-processing-main.yaml
+++ b/satellite-data-processing-main.yaml
@@ -11,6 +11,10 @@
     debug:
       msg: "Processing selected: {{ satellite_data_type }}"
 
+  - name: processing FCI (base tasks)
+    include_tasks: fci-processing/fci-base-tasks.yaml
+    when: satellite_data_type == 'fci'
+
   - name: processing FCI
     include_tasks: fci-processing/fci-processing-tasks.yaml
     when: satellite_data_type == 'fci'


### PR DESCRIPTION
This PR currently fix the hub item on EWC.

Fixes:

```
TASK [Create install directory] ************************************************
[05/12/26 12:46:47] ERROR    ❌ Task 'ansible-playbook -i
                             /home/tervo/.ewccli/outputs/pytroll-processing-0.1.0/ewc-playbooks/hosts-pytroll-processing.ini -u cloud-user
                             --private-key /home/tervo/.ewccli/.ssh/eumetsat-internal-eumetsat-giad_id_rsa
                             /home/tervo/.ewccli/outputs/pytroll-processing-0.1.0/ewc-playbooks/satellite-data-processing-main.yaml' failed on
                             host 'pytroll-processing'
fatal: [10.0.0.48]: FAILED! => {"msg": "The task includes an option with an undefined variable.. 'install_dir' is undefined\n\nThe error appears to be in '/home/tervo/.ewccli/outputs/pytroll-processing-0.1.0/ewc-playbooks/fci-processing/fci-processing-tasks.yaml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Create install directory\n  ^ here\n"}

```

and also:

```
fatal: [10.0.0.46]: FAILED! => {"changed": false, "msg": "Failed to find required executable \"podman\" in paths: /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin/:/usr/local/sbin"}


```